### PR TITLE
fix genRules.py encode bug

### DIFF
--- a/tools/genRules/genRules.py
+++ b/tools/genRules/genRules.py
@@ -22,7 +22,7 @@ parser.add_argument("--fileext", help="Rule file extension", default="yml", type
 args = parser.parse_args()
 
 def CRC32_from_string(string):
-    buf = (binascii.crc32(string.encode('utf8')) & 0xFFFFFFFF)
+    buf = (binascii.crc32(bytes(str(string), "utf-8")) & 0xFFFFFFFF)
     return "%08X" % buf   
 
 def retrieveRule(ruleFile):


### PR DESCRIPTION
I got a bug:
```
multiprocessing.pool.RemoteTraceback:
"""
Traceback (most recent call last):
  File "/usr/lib/python3.8/multiprocessing/pool.py", line 125, in worker
    result = (True, func(*args, **kwds))
  File "/usr/lib/python3.8/multiprocessing/pool.py", line 48, in mapstar
    return list(map(*args))
  File "genRules.py", line 44, in retrieveRule
    d['title']=title + " - " + CRC32_from_string(v)
  File "genRules.py", line 25, in CRC32_from_string
    buf = (binascii.crc32(string.encode('utf8')) & 0xFFFFFFFF)
AttributeError: 'int' object has no attribute 'encode'
"""

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "genRules.py", line 67, in <module>
    outputList = pool.map(retrieveRule, files)
  File "/usr/lib/python3.8/multiprocessing/pool.py", line 364, in map
    return self._map_async(func, iterable, mapstar, chunksize).get()
  File "/usr/lib/python3.8/multiprocessing/pool.py", line 771, in get
    raise self._value
AttributeError: 'int' object has no attribute 'encode'
```

So I replaced it with bytes() instead of using .encode()