### PR TITLE
Windows misconfiguration

### DIFF
--- a/tools/genRules/genRules.py
+++ b/tools/genRules/genRules.py
@@ -25,7 +25,7 @@ class rulesetGenerator:
     def retrieveRule(self, ruleFile):
         try:
             d={}
-            cmd = ["python", self.sigmac, "-d", "--target", "sqlite", "-c", self.config, ruleFile, "--backend-option", f'table={self.table}']
+            cmd = ["python3", self.sigmac, "-d", "--target", "sqlite", "-c", self.config, ruleFile, "--backend-option", f'table={self.table}']
       
             outputRaw = subprocess.run(args=cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, encoding='cp437')
 

--- a/tools/genRules/genRules.py
+++ b/tools/genRules/genRules.py
@@ -24,7 +24,7 @@ class rulesetGenerator:
 
     def retrieveRule(self, ruleFile):
         d={}
-        cmd = [self.sigmac, "-d", "--target", "sqlite", "-c", self.config, ruleFile, "--backend-option", f'table={self.table}']
+        cmd = ["python3", self.sigmac, "-d", "--target", "sqlite", "-c", self.config, ruleFile, "--backend-option", f'table={self.table}']
         outputRaw = subprocess.run(args=cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, encoding='utf-8')
         output = [rule for rule in outputRaw.stdout.split("\n") if not "Feel free" in rule]
         if "unsupported" in str(output):


### PR DESCRIPTION
Windows is not made by default to understand what a python script is or how to run it, even after the python installation. In order to not modify the registry settings, just add a simple element in the command line array, maintain the cross-platform ability and add more stability.