### PR TITLE
isolate invidvidual line parsing errors

### DIFF
--- a/zircolite.py
+++ b/zircolite.py
@@ -1071,7 +1071,14 @@ class evtxExtractor:
         if not "Event" in xmlLine:
             return None
         xmlLine = "<Event>" + xmlLine.split("<Event>")[1]
-        root = etree.fromstring(xmlLine)
+
+        try:
+            # isolate invidvidual line parsing errors
+            root = etree.fromstring(xmlLine)
+        except Exception as ex:
+            self.logger.debug(f"unable to parse line \"{xmlLine}\": {ex}")
+            return None
+
         ns = "http://schemas.microsoft.com/win/2004/08/events/event"
         child = {"#attributes": {"xmlns": ns}}
         for appt in root.getchildren():


### PR DESCRIPTION
This makes sure parsing continues if e.g. an end tag is missing. We observed this behavior with Sysmon on Linux where lines like this were present in the log (i.e. the `</Event>` tag is missing, probably because Sysmon truncates the line):
```
Aug 31 09:40:30 ubuntu sysmon: <Event><System><Provider Name="Linux-Sysmon" Guid="{ff032593-a8d3-4f13-b0d6-01fc615a0f97}"/><EventID>1</EventID><Version>5</Version><Level>4</Level><Task>1</Task><Opcode>0</Opcode><Keywords>0x8000000000000000</Keywords><TimeCreated SystemTime="2022-08-31T07:40:30.235304000Z"/><EventRecordID>6466</EventRecordID><Correlation/><Execution ProcessID="933" ThreadID="933"/><Channel>Linux-Sysmon/Operational</Channel><Computer>ubuntu</Computer><Security UserId="0"/></System><EventData><Data Name="RuleName">-</Data><Data Name="UtcTime">2022-08-31 07:40:30.236</Data><Data Name="ProcessGuid">{40eea3da-106e-630f-55a1-6b0000000000}</Data><Data Name="ProcessId">4969</Data><Data Name="Image">/usr/bin/python3.8</Data><Data Name="FileVersion">-</Data><Data Name="Description">-</Data><Data Name="Product">-</Data><Data Name="Company">-</Data><Data Name="OriginalFileName">-</Data><Data Name="CommandLine">/usr/bin/python3.8 -E -S /usr/lib/python3.8/py_compile.py /usr/lib/python3.8/__future__.py ... /usr/lib/python3.8/fnmatch.py /usr/lib/python3.8/
```