### PR TITLE
Fix Sysmon Blocked Executable rule

### DIFF
--- a/rules/rules_windows_generic_full.json
+++ b/rules/rules_windows_generic_full.json
@@ -17453,7 +17453,7 @@
         ],
         "level": "high",
         "rule": [
-            "SELECT * FROM logs WHERE EventID = '27'"
+            "SELECT * FROM logs WHERE Channel = 'Microsoft-Windows-Sysmon/Operational' AND EventID = '27'"
         ],
         "filename": "sysmon_file_block_exe.yml"
     },


### PR DESCRIPTION
Fix Sysmon Blocked Executable (id: 23b71bc5-953e-4971-be4c-c896cda73fc2) to be triggered only on Sysmon channel