### PR TITLE
Fix race condition

### DIFF
--- a/zircolite_dev.py
+++ b/zircolite_dev.py
@@ -371,7 +371,7 @@ class zircore:
         #if not csv_output:
 
         if not Path(str(tmp_directory)).is_dir():
-            os.mkdir(tmp_directory)
+            os.makedirs(tmp_directory, exist_ok=True)
         if "?mode=memory&cache=shared" in db_location:
             tmp_filename = f'{db_location.replace("file:", "").replace("?mode=memory&cache=shared", "")}.json'
         else:


### PR DESCRIPTION
Hello,

When using `python3 zircolite_dev.py  -e ...`
there is a race condition when creating the temporary folder.
It will crash if the folder has been created by another process 

```
multiprocessing.pool.RemoteTraceback: 
"""
Traceback (most recent call last):
  File "/usr/lib/python3.8/multiprocessing/pool.py", line 125, in worker
    result = (True, func(*args, **kwds))
  File "./zircolite_dev.py", line 1225, in runner_wrapper
    return runner(*args)
  File "./zircolite_dev.py", line 1204, in runner
    zircolite_core = zircore(
  File "./zircolite_dev.py", line 375, in __init__
    os.mkdir(tmp_directory)
FileExistsError: [Errno 17] File exists: 'tmp-output-DJ7ZR9TLEJ'
"""

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "./zircolite_dev.py", line 1654, in <module>
    main()
  File "./zircolite_dev.py", line 1551, in main
    for full_results, rule_results in pool.imap_unordered(runner_wrapper, params_map):
  File "/usr/lib/python3.8/multiprocessing/pool.py", line 868, in next
    raise value
FileExistsError: [Errno 17] File exists: 'tmp-output-DJ7ZR9TLEJ'
```

Also, i suggest to use [pathlib](https://docs.python.org/3/library/pathlib.html). I can provide a pull request if you want.


