### PR TITLE
Update Detection Rule License link on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,6 @@ The Mini-GUI can be used totally offline. It allows you to display and search re
 
 - All the **code** of the project is licensed under the [GNU Lesser General Public License](https://www.gnu.org/licenses/lgpl-3.0.en.html).
 - `evtx_dump` is under the MIT license.
-- The rules are released under the [Detection Rule License (DRL) 1.0](https://github.com/Neo23x0/sigma/blob/master/LICENSE.Detection.Rules.md).
+- The rules are released under the [Detection Rule License (DRL) 1.0](https://github.com/SigmaHQ/Detection-Rule-License/blob/main/LICENSE.Detection.Rules.md).
 
 ---


### PR DESCRIPTION
The old link https://github.com/Neo23x0/sigma/blob/master/LICENSE.Detection.Rules.md doesn't work.