### PR TITLE
Add --strict flag for EVTX parsing to enforce strict error handling

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -560,7 +560,8 @@ def default_args_config():
         timesketch=False,
         navigator_output=None,
         package=False,
-        package_dir=""
+        package_dir="",
+        strict=False,
     )
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1687,6 +1687,29 @@ class TestCLIAdvancedConfiguration:
         assert isinstance(detections, list)
 
 
+class TestCLIStrictEvtxParsing:
+    """Tests for --strict EVTX parsing flag."""
+
+    def test_strict_flag_accepted(self):
+        """--strict flag is accepted without error."""
+        with patch('sys.argv', ['zircolite.py', '--strict', '-v']):
+            with pytest.raises(SystemExit) as exc_info:
+                zircolite_script.main()
+            assert exc_info.value.code == 0
+
+    def test_strict_flag_default_false(self):
+        """--strict defaults to False when not provided."""
+        with patch('sys.argv', ['zircolite.py', '-v']):
+            args = zircolite_script.parse_arguments()
+            assert args.strict is False
+
+    def test_strict_flag_sets_true(self):
+        """--strict sets the strict attribute to True."""
+        with patch('sys.argv', ['zircolite.py', '--strict', '-v']):
+            args = zircolite_script.parse_arguments()
+            assert args.strict is True
+
+
 # Fixture files for Sysmon Linux, XML, EVTXtract, Auditd, and Winlogbeat (sanitized/cropped)
 FIXTURES_DIR = WORKSPACE_ROOT / "tests" / "fixtures"
 SYSMON_LINUX_FIXTURE = FIXTURES_DIR / "sysmon_linux_sample.log"

--- a/tests/test_config_dataclasses.py
+++ b/tests/test_config_dataclasses.py
@@ -51,6 +51,14 @@ class TestExtractorConfigEncoding:
         cfg = ExtractorConfig(csv_input=True)
         assert cfg.encoding is None
 
+    def test_strict_evtx_default_false(self):
+        cfg = ExtractorConfig()
+        assert cfg.strict_evtx is False
+
+    def test_strict_evtx_set_true(self):
+        cfg = ExtractorConfig(strict_evtx=True)
+        assert cfg.strict_evtx is True
+
 
 # =============================================================================
 # RulesetConfig
@@ -133,3 +141,11 @@ class TestProcessingConfigDefaults:
         cfg = ProcessingConfig()
         assert cfg.add_index == []
         assert cfg.remove_index == []
+
+    def test_strict_evtx_default_false(self):
+        cfg = ProcessingConfig()
+        assert cfg.strict_evtx is False
+
+    def test_strict_evtx_set_true(self):
+        cfg = ProcessingConfig(strict_evtx=True)
+        assert cfg.strict_evtx is True

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -109,6 +109,7 @@ class TestProcessingConfig:
         assert config.hashes is False
         assert config.limit == -1
         assert config.time_field == "SystemTime"
+        assert config.strict_evtx is False
 
 
 class TestTimeFilterConfig:
@@ -971,6 +972,21 @@ class TestConfigLoaderMergeWithArgsExtended:
         merged = loader.merge_with_args(config, args)
         assert merged.parallel.max_workers == 8
 
+    def test_strict_evtx_override(self, test_logger):
+        config = ZircoliteConfig()
+        args = self._make_args(strict=True)
+        loader = ConfigLoader(logger=test_logger)
+        merged = loader.merge_with_args(config, args)
+        assert merged.processing.strict_evtx is True
+
+    def test_strict_evtx_default_not_overridden(self, test_logger):
+        config = ZircoliteConfig()
+        config.processing.strict_evtx = False
+        args = self._make_args()
+        loader = ConfigLoader(logger=test_logger)
+        merged = loader.merge_with_args(config, args)
+        assert merged.processing.strict_evtx is False
+
 
 class TestConfigLoaderParseConfigExtended:
     """Additional parse_config tests for edge cases."""
@@ -999,6 +1015,20 @@ class TestConfigLoaderParseConfigExtended:
         loader = ConfigLoader(logger=test_logger)
         config = loader.parse_config(config_dict)
         assert config.output.templates == [{"template": "tmpl.html", "output": "out.html"}]
+
+    def test_parse_config_strict_evtx(self, test_logger):
+        """strict_evtx parsed from processing section."""
+        config_dict = {"processing": {"strict_evtx": True}}
+        loader = ConfigLoader(logger=test_logger)
+        config = loader.parse_config(config_dict)
+        assert config.processing.strict_evtx is True
+
+    def test_parse_config_strict_evtx_default(self, test_logger):
+        """strict_evtx defaults to False when not in YAML."""
+        config_dict = {"processing": {}}
+        loader = ConfigLoader(logger=test_logger)
+        config = loader.parse_config(config_dict)
+        assert config.processing.strict_evtx is False
 
 
 class TestConfigLoaderIntegration:

--- a/tests/test_streaming_processor.py
+++ b/tests/test_streaming_processor.py
@@ -1235,6 +1235,119 @@ class TestStreamingEventProcessorErrorPaths:
         assert ".7z" not in parser_path
 
 
+class TestStreamingEvtxStrictMode:
+    """Tests for lenient (default) and strict EVTX parsing modes."""
+
+    @patch('zircolite.streaming.PyEvtxParser')
+    def test_lenient_mode_logs_warning_on_chunk_error(
+        self, mock_parser_cls, field_mappings_file, test_logger, default_args_config, tmp_path, sample_windows_event
+    ):
+        """In lenient mode (default), chunk errors log a warning and yield events recovered before the error."""
+        evtx_file = tmp_path / "corrupt.evtx"
+        evtx_file.write_bytes(b"ElfFile\x00\x00")
+
+        good_record = {"data": json.dumps(sample_windows_event)}
+
+        def records_with_error():
+            yield good_record
+            raise RuntimeError("Failed to parse chunk header")
+
+        mock_parser = MagicMock()
+        mock_parser.records_json.side_effect = records_with_error
+        mock_parser_cls.return_value = mock_parser
+
+        processor = StreamingEventProcessor(
+            config_file=field_mappings_file,
+            args_config=default_args_config,
+            logger=test_logger,
+        )
+        events = list(processor.stream_evtx_events(str(evtx_file)))
+        assert len(events) == 1
+        assert "OriginalLogfile" in events[0]
+
+    @patch('zircolite.streaming.PyEvtxParser')
+    def test_strict_mode_raises_on_chunk_error(
+        self, mock_parser_cls, field_mappings_file, test_logger, default_args_config, tmp_path, sample_windows_event
+    ):
+        """In strict mode, chunk errors propagate as exceptions."""
+        evtx_file = tmp_path / "corrupt.evtx"
+        evtx_file.write_bytes(b"ElfFile\x00\x00")
+
+        def records_with_error():
+            yield {"data": json.dumps(sample_windows_event)}
+            raise RuntimeError("Failed to parse chunk header")
+
+        mock_parser = MagicMock()
+        mock_parser.records_json.side_effect = records_with_error
+        mock_parser_cls.return_value = mock_parser
+
+        proc_config = ProcessingConfig(strict_evtx=True)
+        processor = StreamingEventProcessor(
+            config_file=field_mappings_file,
+            args_config=default_args_config,
+            processing_config=proc_config,
+            logger=test_logger,
+        )
+        with pytest.raises(RuntimeError, match="Failed to parse chunk header"):
+            list(processor.stream_evtx_events(str(evtx_file)))
+
+    @patch('zircolite.streaming.PyEvtxParser')
+    def test_lenient_mode_still_handles_invalid_evtx_for_7z(
+        self, mock_parser_cls, field_mappings_file, test_logger, default_args_config, tmp_path
+    ):
+        """Invalid EVTX signature inside .7z still logs error and returns early in lenient mode."""
+        evtx_file = tmp_path / "bad.evtx.7z"
+        evtx_file.write_bytes(b"not-evtx")
+
+        mock_parser_cls.side_effect = RuntimeError("Invalid EVTX signature (ElfFile0)")
+        processor = StreamingEventProcessor(
+            config_file=field_mappings_file,
+            args_config=default_args_config,
+            logger=test_logger,
+        )
+        events = list(processor.stream_evtx_events(str(evtx_file)))
+        assert events == []
+
+    @patch('zircolite.streaming.PyEvtxParser')
+    def test_strict_mode_raises_on_parser_construction_failure(
+        self, mock_parser_cls, field_mappings_file, test_logger, default_args_config, tmp_path
+    ):
+        """In strict mode, parser construction failures raise."""
+        evtx_file = tmp_path / "bad.evtx"
+        evtx_file.write_bytes(b"ElfFile\x00\x00")
+
+        mock_parser_cls.side_effect = RuntimeError("EVTX open failed")
+        proc_config = ProcessingConfig(strict_evtx=True)
+        processor = StreamingEventProcessor(
+            config_file=field_mappings_file,
+            args_config=default_args_config,
+            processing_config=proc_config,
+            logger=test_logger,
+        )
+        with pytest.raises(RuntimeError, match="EVTX open failed"):
+            list(processor.stream_evtx_events(str(evtx_file)))
+
+    def test_strict_evtx_flag_stored_from_config(
+        self, field_mappings_file, test_logger, default_args_config
+    ):
+        """strict_evtx is correctly read from ProcessingConfig."""
+        proc_strict = ProcessingConfig(strict_evtx=True)
+        processor_strict = StreamingEventProcessor(
+            config_file=field_mappings_file,
+            args_config=default_args_config,
+            processing_config=proc_strict,
+            logger=test_logger,
+        )
+        assert processor_strict.strict_evtx is True
+
+        processor_lenient = StreamingEventProcessor(
+            config_file=field_mappings_file,
+            args_config=default_args_config,
+            logger=test_logger,
+        )
+        assert processor_lenient.strict_evtx is False
+
+
 class TestStreamingTransformInitAndResolve:
     """Tests for transform_categories init and _resolve_file_transforms."""
 

--- a/zircolite.py
+++ b/zircolite.py
@@ -188,6 +188,7 @@ def parse_arguments() -> argparse.Namespace:
     config_formats_args.add_argument("--unified-db", "--all-in-one", help="Force unified database mode (all files in one DB, enables cross-file correlation)", action='store_true')
     config_formats_args.add_argument("--no-auto-mode", help="Disable automatic processing mode selection based on file analysis", action='store_true')
     config_formats_args.add_argument("--no-auto-detect", help="Disable automatic log type and timestamp detection (use explicit format flags instead)", action='store_true')
+    config_formats_args.add_argument("--strict", help="Strict EVTX parsing: stop on corrupted or malformed chunks instead of skipping them (default: lenient, recovers as many events as possible)", action='store_true')
     config_formats_args.add_argument("--add-index", help="Create an index on the given column(s). Can be repeated or list multiple columns (e.g. --add-index Channel EventID).", action='append', nargs='+', metavar="COL", default=[])
     config_formats_args.add_argument("--remove-index", help="Drop the given index name(s) after creation. Can be repeated or list multiple (e.g. --remove-index idx_channel idx_eventid).", action='append', nargs='+', metavar="IDX", default=[])
 
@@ -519,6 +520,8 @@ def _apply_yaml_processing_config(
     if yaml_config.processing.remove_index:
         existing = _flatten_add_remove_index(getattr(args, 'remove_index', None))
         args.remove_index = [existing + list(yaml_config.processing.remove_index)]
+    if yaml_config.processing.strict_evtx:
+        args.strict = True
     # Time filters
     if yaml_config.time_filter.after != '1970-01-01T00:00:00':
         args.after = yaml_config.time_filter.after
@@ -1248,6 +1251,7 @@ def main() -> None:
         archive_password=getattr(args, 'archive_password', None),
         add_index=_flatten_add_remove_index(getattr(args, 'add_index', None)),
         remove_index=_flatten_add_remove_index(getattr(args, 'remove_index', None)),
+        strict_evtx=getattr(args, 'strict', False),
     )
 
     # Run processing and collect results

--- a/zircolite/config.py
+++ b/zircolite/config.py
@@ -47,6 +47,9 @@ class ProcessingConfig:
     # Archive decryption
     archive_password: Optional[str] = None
 
+    # EVTX parsing strictness (False = lenient/skip bad chunks, True = stop on errors)
+    strict_evtx: bool = False
+
 
 @dataclass
 class ExtractorConfig:
@@ -65,6 +68,9 @@ class ExtractorConfig:
     # Processing options
     tmp_dir: Optional[str] = None
     encoding: Optional[str] = None
+
+    # EVTX parsing strictness
+    strict_evtx: bool = False
     
     def __post_init__(self) -> None:
         """Set default encoding based on input type if not specified."""

--- a/zircolite/config_loader.py
+++ b/zircolite/config_loader.py
@@ -73,6 +73,7 @@ class ProcessingConfig:
     transform_categories: Optional[list] = None
     add_index: Optional[List[str]] = None
     remove_index: Optional[List[str]] = None
+    strict_evtx: bool = False
 
 
 @dataclass
@@ -226,6 +227,7 @@ class ConfigLoader:
                 transform_categories=proc.get('transform_categories'),
                 add_index=proc.get('add_index'),
                 remove_index=proc.get('remove_index'),
+                strict_evtx=proc.get('strict_evtx', False),
             )
         
         # Parse time_filter section
@@ -439,6 +441,8 @@ class ConfigLoader:
             config.processing.add_index = [x for group in args.add_index for x in group]
         if getattr(args, 'remove_index', None):
             config.processing.remove_index = [x for group in args.remove_index for x in group]
+        if hasattr(args, 'strict') and args.strict:
+            config.processing.strict_evtx = True
 
         # Time filter overrides
         if hasattr(args, 'after') and args.after != '1970-01-01T00:00:00':
@@ -576,6 +580,10 @@ processing:
   # transform_categories:
   #   - commandline
   #   - process
+
+  # Strict EVTX parsing: stop on corrupted or malformed chunks (default: false)
+  # When false (lenient), recovers as many events as possible from damaged files
+  strict_evtx: false
 
 # Time-based event filtering
 time_filter:

--- a/zircolite/core.py
+++ b/zircolite/core.py
@@ -89,6 +89,7 @@ class ZircoliteCore:
         "archive_password",
         "add_index",
         "remove_index",
+        "strict_evtx",
     )
     _cursor: Optional[sqlite3.Cursor]
 
@@ -129,6 +130,7 @@ class ZircoliteCore:
         self.archive_password = proc.archive_password
         self.add_index = list(proc.add_index) if proc.add_index else []
         self.remove_index = list(proc.remove_index) if proc.remove_index else []
+        self.strict_evtx = proc.strict_evtx
         # Cache for escaped identifiers to avoid repeated string operations
         self._escape_cache: dict = {}
         # Reusable cursor to avoid creating new cursors for each query
@@ -908,6 +910,7 @@ class ZircoliteCore:
             hashes=self.hashes,
             disable_progress=disable_progress or self.disable_progress,
             archive_password=self.archive_password,
+            strict_evtx=self.strict_evtx,
         )
         processor = StreamingEventProcessor(
             config_file=self.config,

--- a/zircolite/extractor.py
+++ b/zircolite/extractor.py
@@ -71,6 +71,7 @@ class EvtxExtractor:
         self.evtxtract = cfg.evtxtract
         self.csvInput = cfg.csv_input
         self.encoding = cfg.encoding
+        self.strict_evtx = cfg.strict_evtx
         
     def run_using_bindings(self, file: Union[Path, str]) -> None:
         """Convert EVTX to JSON using evtx_dump bindings. Drop resulting JSON files in a tmp folder."""
@@ -87,7 +88,13 @@ class EvtxExtractor:
                         continue
                     f.write(f"{json.dumps(json.loads(data)).decode('utf-8')}\n")
         except Exception as e:
-            self.logger.error(f"[red]    [-] Cannot use PyEvtxParser : {e}[/]")
+            if self.strict_evtx:
+                self.logger.error(f"[red]    [-] Cannot use PyEvtxParser : {e}[/]")
+                raise
+            self.logger.warning(
+                f"[yellow]    [!] EVTX parsing error in {file}: {e} — "
+                "recovered events before the error were kept (use [cyan]--strict[/] to abort on parse errors)[/]"
+            )
 
     def get_time(self, line: str) -> str:
         """Extract timestamp from auditd log line."""

--- a/zircolite/processing.py
+++ b/zircolite/processing.py
@@ -98,6 +98,7 @@ class ProcessingContext:
     archive_password: Optional[str] = None
     add_index: list = field(default_factory=list)
     remove_index: list = field(default_factory=list)
+    strict_evtx: bool = False
 
     # Cached formatted time strings (computed in __post_init__)
     time_after_str: str = field(init=False, repr=False)
@@ -133,6 +134,7 @@ def create_zircolite_core(
         archive_password=ctx.archive_password,
         add_index=ctx.add_index,
         remove_index=ctx.remove_index,
+        strict_evtx=ctx.strict_evtx,
     )
     return ZircoliteCore(ctx.config, proc_config, logger=ctx.logger)
 
@@ -154,6 +156,7 @@ def create_worker_core(ctx: ProcessingContext, worker_id: int) -> ZircoliteCore:
         archive_password=ctx.archive_password,
         add_index=ctx.add_index,
         remove_index=ctx.remove_index,
+        strict_evtx=ctx.strict_evtx,
     )
     return ZircoliteCore(ctx.config, proc_config, logger=silent_logger)
 

--- a/zircolite/streaming.py
+++ b/zircolite/streaming.py
@@ -202,6 +202,8 @@ class StreamingEventProcessor:
         "archive_password",
         # One-shot flag: warn once when --timefield value is absent from events
         "_timefield_warned",
+        # EVTX parsing strictness
+        "strict_evtx",
     )
     enabled_transforms_set: Optional[FrozenSet[Any]]
     _detected_time_field: Optional[str]
@@ -241,6 +243,7 @@ class StreamingEventProcessor:
         self.disable_progress = proc.disable_progress
         self.batch_size = proc.batch_size
         self.archive_password = proc.archive_password
+        self.strict_evtx = proc.strict_evtx
 
         # Event filter for early filtering based on channel/eventID
         self.event_filter = event_filter
@@ -921,8 +924,14 @@ class StreamingEventProcessor:
                         "Use [cyan]-e/--events[/] without forcing EVTX so auto-detect can run, or [cyan]--json-input[/] for JSON in archives.[/]"
                     )
                     return
-            self.logger.error(
-                f"[red]    [-] Error streaming EVTX file {evtx_file}: {e}[/]"
+            if self.strict_evtx:
+                self.logger.error(
+                    f"[red]    [-] Error streaming EVTX file {evtx_file}: {e}[/]"
+                )
+                raise
+            self.logger.warning(
+                f"[yellow]    [!] EVTX parsing error in {evtx_file}: {e} — "
+                "recovered events before the error were kept (use [cyan]--strict[/] to abort on parse errors)[/]"
             )
         finally:
             if tmp_path and os.path.exists(tmp_path):


### PR DESCRIPTION
## Summary

- Make EVTX parsing lenient by default: skip corrupted/malformed chunks and recover as many valid events as possible instead of aborting
- Add `--strict` CLI flag to restore previous strict behavior (stop on EVTX parse errors)

Fix #128 