### PR TITLE
Release 3.7.1

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -10,7 +10,7 @@ assignees: ''
 
 - **OS**: (e.g. Windows 11, macOS 14, Ubuntu 22.04)
 - **Python version**: (e.g. 3.10, 3.12)
-- **Zircolite version**: (e.g. 3.7.0 — run `python zircolite.py --version` if available)
+- **Zircolite version**: (e.g. 3.7.1 — run `python zircolite.py --version` if available)
 
 ## Steps to reproduce
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,12 +12,6 @@ LABEL org.opencontainers.image.title="Zircolite" \
 
 WORKDIR ${ZIRCOLITE_INSTALL_PREFIX}/zircolite
 
-# Install system dependencies
-RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends git && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
 # Copy and install Python dependencies
 COPY ${ZIRCOLITE_REQUIREMENTS_FILE} .
 RUN pip install --no-cache-dir -r ${ZIRCOLITE_REQUIREMENTS_FILE} && \
@@ -36,6 +30,13 @@ COPY zircolite.py .
 # Set permissions and update rules in single layer
 RUN chmod 0755 zircolite.py && \
     python3 zircolite.py -U
+
+# Run as a non-root user. chown happens after -U so the unprivileged user
+# owns the refreshed rulesets and can read every asset under the install prefix.
+RUN groupadd --system zircolite && \
+    useradd --system --gid zircolite --home-dir ${ZIRCOLITE_INSTALL_PREFIX}/zircolite --shell /usr/sbin/nologin zircolite && \
+    chown -R zircolite:zircolite ${ZIRCOLITE_INSTALL_PREFIX}/zircolite
+USER zircolite
 
 ENTRYPOINT ["python3", "zircolite.py"]
 CMD ["--help"]

--- a/docs/Advanced.md
+++ b/docs/Advanced.md
@@ -874,6 +874,7 @@ Zircolite provides a templating system based on Jinja2. It allows you to change 
 
 - `--template <template_filename>`
 - `--templateOutput <output_filename>`
+- `--template-append`
 
 For Timesketch you can use the shortcut `--timesketch`: it uses `exportForTimesketch.tmpl` and writes to a file named `timesketch-<RAND>.json` (4-character random suffix) so you can run multiple exports without overwriting.
 
@@ -891,6 +892,29 @@ python3 zircolite.py --evtx sample.evtx --ruleset rules/rules_windows_merged.jso
 For ATT&CK Navigator use `--navigator-output` (writes to `navigator-<RAND>.json`) or `--navigator-output mylayer.json` for a custom filename.
 
 It is possible to use multiple templates if you provide a `--templateOutput` argument for each `--template` argument.
+
+### Append mode
+
+By default, template output files are overwritten on every run so that re-running Zircolite over the same logs is idempotent. If you instead want to accumulate template output across multiple runs (for example, building a cumulative NDJSON feed for Splunk or ELK ingestion), pass `--template-append`:
+
+```shell
+python3 zircolite.py --evtx logs/ --ruleset rules/rules_windows_merged.json \
+    --template templates/exportForSplunk.tmpl --templateOutput exportForSplunk.ndjson \
+    --template-append
+```
+
+The same setting can be expressed in YAML:
+
+```yaml
+output:
+  templates:
+    - template: templates/exportForSplunk.tmpl
+      output: exportForSplunk.ndjson
+  template_append: true
+```
+
+> [!WARNING]
+> Append mode is intended for **line-oriented** templates such as `exportForSplunk.tmpl`, `exportForELK.tmpl`, `exportForTimesketch.tmpl`, and `exportNDJSON.tmpl`. It is not appropriate for templates that produce a **single JSON document**, such as `exportForAttackNavigator.tmpl` or `exportForSARIF.tmpl` — appending to those will produce invalid output.
 
 ### Available templates
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Zircolite Documentation
 
-Documentation for **Zircolite 3.7.0**. Zircolite is a standalone SIGMA-based detection tool for EVTX, Auditd, Sysmon for Linux, XML, CSV, and JSONL/NDJSON logs. It uses SQLite as a backend for SIGMA rule execution.
+Documentation for **Zircolite 3.7.1**. Zircolite is a standalone SIGMA-based detection tool for EVTX, Auditd, Sysmon for Linux, XML, CSV, and JSONL/NDJSON logs. It uses SQLite as a backend for SIGMA rule execution.
 
 **Zircolite** supports the following log sources:
 

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -278,6 +278,7 @@ Parallel processing includes several automatic optimizations:
 |--------|-------------|
 | `--template` | Jinja2 template for output |
 | `--templateOutput` | Output file for template |
+| `--template-append` | Append to template output files instead of overwriting them |
 | `--timesketch` | Shortcut: Timesketch template → `timesketch-<RAND>.json` |
 | `--navigator-output` | Shortcut: ATT&CK Navigator layer → `navigator-<RAND>.json` (or optional custom filename) |
 | `--package` | Create ZircoGui package |

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -557,6 +557,7 @@ def default_args_config():
         parallel_memory_limit=85.0,
         template=None,
         templateOutput=None,
+        template_append=False,
         timesketch=False,
         navigator_output=None,
         package=False,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1210,6 +1210,111 @@ Alert: {{ elem.title }} ({{ elem.rule_level }})
             content = f.read()
         assert "Alert:" in content
 
+    def test_template_append_accumulates_across_runs(self, tmp_path):
+        """--template-append should append to existing template output across runs."""
+        events_file = tmp_path / "events.json"
+        events_file.write_text('{"Event": {"System": {"EventID": 1}, "EventData": {"CommandLine": "powershell.exe"}}}')
+
+        ruleset_file = tmp_path / "ruleset.json"
+        ruleset_file.write_text(json.dumps([{
+            "title": "Test Rule",
+            "id": "test-001",
+            "level": "high",
+            "tags": [],
+            "rule": ["SELECT * FROM logs WHERE CommandLine LIKE '%powershell%'"]
+        }]))
+
+        config_file = tmp_path / "config.json"
+        config_file.write_text(json.dumps({
+            "exclusions": [],
+            "useless": [],
+            "mappings": {
+                "Event.System.EventID": "EventID",
+                "Event.EventData.CommandLine": "CommandLine"
+            },
+            "alias": {},
+            "split": {},
+            "transforms_enabled": False,
+            "transforms": {}
+        }))
+
+        template_file = tmp_path / "template.tmpl"
+        template_file.write_text("RUN|")
+
+        output_file = tmp_path / "detected_events.json"
+        template_output = tmp_path / "alerts.txt"
+
+        argv_base = [
+            'zircolite.py',
+            '-e', str(events_file),
+            '-r', str(ruleset_file),
+            '-c', str(config_file),
+            '-j',
+            '-o', str(output_file),
+            '--template', str(template_file),
+            '--templateOutput', str(template_output),
+            '--template-append',
+        ] + get_log_arg(tmp_path)
+
+        with patch('sys.argv', argv_base):
+            zircolite_script.main()
+        with patch('sys.argv', argv_base):
+            zircolite_script.main()
+
+        assert template_output.read_text() == "RUN|RUN|"
+
+    def test_template_append_disabled_overwrites(self, tmp_path):
+        """Without --template-append, repeated runs overwrite the template output."""
+        events_file = tmp_path / "events.json"
+        events_file.write_text('{"Event": {"System": {"EventID": 1}, "EventData": {"CommandLine": "powershell.exe"}}}')
+
+        ruleset_file = tmp_path / "ruleset.json"
+        ruleset_file.write_text(json.dumps([{
+            "title": "Test Rule",
+            "id": "test-001",
+            "level": "high",
+            "tags": [],
+            "rule": ["SELECT * FROM logs WHERE CommandLine LIKE '%powershell%'"]
+        }]))
+
+        config_file = tmp_path / "config.json"
+        config_file.write_text(json.dumps({
+            "exclusions": [],
+            "useless": [],
+            "mappings": {
+                "Event.System.EventID": "EventID",
+                "Event.EventData.CommandLine": "CommandLine"
+            },
+            "alias": {},
+            "split": {},
+            "transforms_enabled": False,
+            "transforms": {}
+        }))
+
+        template_file = tmp_path / "template.tmpl"
+        template_file.write_text("ONCE")
+
+        output_file = tmp_path / "detected_events.json"
+        template_output = tmp_path / "alerts.txt"
+
+        argv_base = [
+            'zircolite.py',
+            '-e', str(events_file),
+            '-r', str(ruleset_file),
+            '-c', str(config_file),
+            '-j',
+            '-o', str(output_file),
+            '--template', str(template_file),
+            '--templateOutput', str(template_output),
+        ] + get_log_arg(tmp_path)
+
+        with patch('sys.argv', argv_base):
+            zircolite_script.main()
+        with patch('sys.argv', argv_base):
+            zircolite_script.main()
+
+        assert template_output.read_text() == "ONCE"
+
     def test_navigator_output_creates_empty_layer_without_detections(self, tmp_path):
         """--navigator-output should emit a valid empty layer when no rules match."""
         events_file = tmp_path / "events.json"

--- a/tests/test_config_dataclasses.py
+++ b/tests/test_config_dataclasses.py
@@ -93,6 +93,7 @@ class TestTemplateConfig:
         assert cfg.template == []
         assert cfg.template_output == []
         assert cfg.time_field == ""
+        assert cfg.append is False
 
     def test_list_independence(self):
         a = TemplateConfig()

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -1030,6 +1030,29 @@ class TestConfigLoaderParseConfigExtended:
         config = loader.parse_config(config_dict)
         assert config.processing.strict_evtx is False
 
+    def test_parse_config_template_append_default(self, test_logger):
+        """template_append defaults to False when not in YAML."""
+        config_dict = {"output": {}}
+        loader = ConfigLoader(logger=test_logger)
+        config = loader.parse_config(config_dict)
+        assert config.output.template_append is False
+
+    def test_parse_config_template_append_true(self, test_logger):
+        """template_append is parsed from output section."""
+        config_dict = {"output": {"template_append": True}}
+        loader = ConfigLoader(logger=test_logger)
+        config = loader.parse_config(config_dict)
+        assert config.output.template_append is True
+
+    def test_template_append_cli_override(self, test_logger):
+        """CLI --template-append flag sets output.template_append on merge."""
+        from argparse import Namespace
+        config = ZircoliteConfig()
+        args = Namespace(template_append=True)
+        loader = ConfigLoader(logger=test_logger)
+        merged = loader.merge_with_args(config, args)
+        assert merged.output.template_append is True
+
 
 class TestConfigLoaderIntegration:
     """Integration tests for ConfigLoader."""

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -84,16 +84,16 @@ class TestBannerAndSection:
     def test_print_banner_visible_when_not_quiet(self):
         set_quiet_mode(False)
         with console.capture() as capture:
-            print_banner("3.7.0")
+            print_banner("3.7.1")
         out = capture.get()
         assert "Standalone Sigma" in out or "Sigma" in out
-        assert "3.7.0" in out
+        assert "3.7.1" in out
 
     def test_print_banner_suppressed_when_quiet(self):
         set_quiet_mode(True)
         try:
             with console.capture() as capture:
-                print_banner("3.7.0")
+                print_banner("3.7.1")
             assert capture.get() == ""
         finally:
             set_quiet_mode(False)

--- a/tests/test_template_engine.py
+++ b/tests/test_template_engine.py
@@ -190,6 +190,87 @@ class TestTemplateEngineRun:
         engine.run(sample_detection_results)
 
 
+class TestTemplateEngineAppendMode:
+    """Tests for the append=True option (issue #132)."""
+
+    def test_default_overwrites(self, simple_template, tmp_path, test_logger, sample_detection_results):
+        """By default the engine still overwrites; append flag is False."""
+        output_file = str(tmp_path / "out.txt")
+        Path(output_file).write_text("preexisting\n")
+
+        engine = TemplateEngine(logger=test_logger)
+        assert engine.append is False
+        engine.generate_from_template(simple_template, output_file, sample_detection_results)
+
+        content = Path(output_file).read_text()
+        assert "preexisting" not in content
+
+    def test_append_via_config_accumulates(self, tmp_path, test_logger, sample_detection_results):
+        """Engine-wide append=True keeps previous content and appends."""
+        template_file = tmp_path / "tmpl.tmpl"
+        template_file.write_text("X")
+        output_file = str(tmp_path / "out.txt")
+
+        cfg = TemplateConfig(
+            template=[[str(template_file)]],
+            template_output=[[output_file]],
+            append=True,
+        )
+        engine = TemplateEngine(template_config=cfg, logger=test_logger)
+
+        engine.generate_from_template(str(template_file), output_file, sample_detection_results)
+        engine.generate_from_template(str(template_file), output_file, sample_detection_results)
+
+        assert Path(output_file).read_text() == "XX"
+
+    def test_append_preserves_existing_content(self, tmp_path, test_logger, sample_detection_results):
+        """append=True keeps any pre-existing file content untouched."""
+        template_file = tmp_path / "tmpl.tmpl"
+        template_file.write_text("rendered")
+        output_file = tmp_path / "out.txt"
+        output_file.write_text("old data\n")
+
+        cfg = TemplateConfig(append=True)
+        engine = TemplateEngine(template_config=cfg, logger=test_logger)
+        engine.generate_from_template(str(template_file), str(output_file), sample_detection_results)
+
+        assert output_file.read_text() == "old data\nrendered"
+
+    def test_append_per_call_override(self, tmp_path, test_logger, sample_detection_results):
+        """The append parameter on generate_from_template overrides the engine setting."""
+        template_file = tmp_path / "tmpl.tmpl"
+        template_file.write_text("Y")
+        output_file = tmp_path / "out.txt"
+
+        engine = TemplateEngine(logger=test_logger)
+        # First write
+        engine.generate_from_template(str(template_file), str(output_file), sample_detection_results)
+        # Force append for the second call
+        engine.generate_from_template(
+            str(template_file), str(output_file), sample_detection_results, append=True
+        )
+
+        assert output_file.read_text() == "YY"
+
+    def test_run_uses_append_setting(self, tmp_path, test_logger, sample_detection_results):
+        """run() honours the engine-wide append flag for every configured template."""
+        template_file = tmp_path / "tmpl.tmpl"
+        template_file.write_text("Z")
+        output_file = str(tmp_path / "out.txt")
+        Path(output_file).write_text("seed\n")
+
+        cfg = TemplateConfig(
+            template=[[str(template_file)]],
+            template_output=[[output_file]],
+            append=True,
+        )
+        engine = TemplateEngine(template_config=cfg, logger=test_logger)
+        engine.run(sample_detection_results)
+        engine.run(sample_detection_results)
+
+        assert Path(output_file).read_text() == "seed\nZZ"
+
+
 class TestTemplateEngineJinjaFeatures:
     """Tests for Jinja2 template features."""
     

--- a/zircolite.py
+++ b/zircolite.py
@@ -1024,7 +1024,7 @@ def _run_processing(
 # MAIN
 ################################################################
 def main() -> None:
-    version = "3.7.0"
+    version = "3.7.1"
     args = parse_arguments()
 
     install_signal_handler()

--- a/zircolite.py
+++ b/zircolite.py
@@ -221,6 +221,7 @@ def parse_arguments() -> argparse.Namespace:
     templating_formats_args = parser.add_argument_group('🎨 TEMPLATING AND MINI GUI')
     templating_formats_args.add_argument("-t", "--template", help="Jinja2 template to use for output generation", type=str, action='append', nargs='+')
     templating_formats_args.add_argument("-T", "--templateOutput", "--template-output", help="Output file for Jinja2 template results", type=str, action='append', nargs='+')
+    templating_formats_args.add_argument("--template-append", help="Append to template output files instead of overwriting them. Useful for accumulating results across multiple runs (e.g. cumulative NDJSON exports). Note: not all templates produce append-safe output (single-document JSON layers will become invalid).", action='store_true', dest='template_append')
     templating_formats_args.add_argument("--timesketch", help="Shortcut: use Timesketch template and write to timesketch-<RAND>.json", action='store_true')
     templating_formats_args.add_argument("--navigator-output", help="Shortcut: generate ATT&CK Navigator layer JSON and write to navigator-<RAND>.json (or specify a custom filename)", type=str, metavar="OUTPUT_FILE", nargs='?', const="")
     templating_formats_args.add_argument("-G", "--package", help="Create a ZircoGui/Mini GUI package", action='store_true')
@@ -484,6 +485,8 @@ def _apply_yaml_output_config(
     if yaml_config.output.templates and not args.template:
         args.template = [[t['template']] for t in yaml_config.output.templates]
         args.templateOutput = [[t['output']] for t in yaml_config.output.templates]
+    if getattr(yaml_config.output, 'template_append', False) and not getattr(args, 'template_append', False):
+        args.template_append = True
     if yaml_config.output.package:
         args.package = True
     if yaml_config.output.package_dir:
@@ -619,7 +622,8 @@ def handle_templating(
         tmpl_config = TemplateConfig(
             template=args.template,
             template_output=args.templateOutput,
-            time_field=ctx.time_field
+            time_field=ctx.time_field,
+            append=getattr(args, 'template_append', False),
         )
         template_generator = TemplateEngine(tmpl_config, logger=ctx.logger)
         template_generator.run(results)

--- a/zircolite/__init__.py
+++ b/zircolite/__init__.py
@@ -219,4 +219,4 @@ __all__ = [
     'print_detection',
 ]
 
-__version__ = "3.7.0"
+__version__ = "3.7.1"

--- a/zircolite/config.py
+++ b/zircolite/config.py
@@ -108,6 +108,10 @@ class TemplateConfig:
     template: List[List[str]] = field(default_factory=list)
     template_output: List[List[str]] = field(default_factory=list)
     time_field: str = ""
+    # When True, template output files are opened in append mode rather than
+    # being overwritten. Useful for accumulating results across multiple runs
+    # (e.g. cumulative NDJSON exports). See issue #132.
+    append: bool = False
 
 
 @dataclass

--- a/zircolite/config_loader.py
+++ b/zircolite/config_loader.py
@@ -50,6 +50,7 @@ class OutputConfig:
     template: Optional[str] = None
     template_output: Optional[str] = None
     templates: Optional[List[Dict[str, str]]] = None  # List of {template, output} pairs
+    template_append: bool = False
     package: bool = False
     package_dir: str = ""
     keep_flat: bool = False
@@ -204,6 +205,7 @@ class ConfigLoader:
                 template=out.get('template'),
                 template_output=out.get('template_output'),
                 templates=templates,
+                template_append=out.get('template_append', False),
                 package=out.get('package', False),
                 package_dir=out.get('package_dir', ''),
                 keep_flat=out.get('keep_flat', False),
@@ -405,6 +407,8 @@ class ConfigLoader:
                 else:
                     output = f"output_{i}.txt"
                 config.output.templates.append({'template': tmpl[0], 'output': output})
+        if getattr(args, 'template_append', False):
+            config.output.template_append = True
         if hasattr(args, 'package') and args.package:
             config.output.package = True
         if hasattr(args, 'package_dir') and args.package_dir:
@@ -533,6 +537,13 @@ output:
   #     output: splunk_events.json
   #   - template: templates/exportForELK.tmpl
   #     output: elk_events.json
+
+  # Append to template output files instead of overwriting them on each run.
+  # Useful for accumulating results across multiple runs (e.g. cumulative
+  # NDJSON exports). Not all templates produce append-safe output: single-
+  # document JSON exports (such as the ATT&CK Navigator layer) become
+  # invalid when concatenated.
+  template_append: false
   
   # Create Mini-GUI package
   package: false

--- a/zircolite/templates.py
+++ b/zircolite/templates.py
@@ -151,19 +151,26 @@ class TemplateEngine:
         self.template = cfg.template
         self.template_output = cfg.template_output
         self.time_field = cfg.time_field
-    
+        self.append = cfg.append
+
     def generate_from_template(
         self,
         template_file: str,
         output_filename: str,
         data: List[Dict[str, Any]],
+        append: Optional[bool] = None,
     ) -> None:
-        """Use Jinja2 to output data in a specific format."""
+        """Use Jinja2 to output data in a specific format.
+
+        If ``append`` is ``None``, the engine-wide ``self.append`` setting is
+        used. Pass ``True``/``False`` explicitly to override per-call.
+        """
         try:
             with open(template_file, 'r', encoding='utf-8') as tmpl:
                 template = _make_jinja2_env().from_string(tmpl.read())
 
-            with open(output_filename, 'w', encoding='utf-8') as tpl:
+            mode = 'a' if (self.append if append is None else append) else 'w'
+            with open(output_filename, mode, encoding='utf-8') as tpl:
                 tpl.write(template.render(data=data, timeField=self.time_field))
         except Exception as e:
             self.logger.error("[red]    [-] Template error, activate debug mode to check for errors[/]")
@@ -172,7 +179,10 @@ class TemplateEngine:
     def run(self, data: List[Dict[str, Any]]) -> None:
         """Run template generation for all configured templates."""
         for template_spec, output_spec in zip(self.template, self.template_output):
-            self.logger.info(f'[+] Applying template "{template_spec[0]}", outputting to : {output_spec[0]}')
+            mode_label = "appending" if self.append else "writing"
+            self.logger.info(
+                f'[+] Applying template "{template_spec[0]}", {mode_label} to : {output_spec[0]}'
+            )
             self.generate_from_template(template_spec[0], output_spec[0], data)
 
 


### PR DESCRIPTION
## What's Changed

### Fixes
- **`--template-append`** (#133, fixes #132) — opt-in CLI flag (also `output.template_append: true` in the YAML config) that switches all configured `--templateOutput` files to append mode for that run. Restores the pre-3.0 behavior for users who build cumulative NDJSON feeds for Splunk/ELK across multiple runs. The default stays as overwrite, so single-document exports such as the ATT&CK Navigator layer or SARIF remain valid.

### Internal
- Hardened `Dockerfile`: dropped the unused `git` apt step and now runs as a non-root user.

**Full Changelog**: https://github.com/wagga40/Zircolite/compare/v3.7.0...release/v3.7.1

Made with [Cursor](https://cursor.com)