### PR TITLE
Speed up event flattening hot path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,10 @@ Taskfile.dev.yml
 *.sublime-workspace
 *.sublime-project
 CLAUDE.md
+.claude
+.mypy_cache
+.pytest_cache
+.ruff_cache
 
 coverage/
 htmlcov/

--- a/docs/Internals.md
+++ b/docs/Internals.md
@@ -79,35 +79,6 @@ flowchart TB
 | **5. Splits** | Parse key=value strings | `"a=1 b=2"` → `{a:1, b:2}` |
 | **6. Transforms** | Custom Python code (sandboxed) | Extract filename from path |
 
-### Flattening Hot Path
-
-Flattening is the dominant cost of ingestion: every leaf of every event passes
-through `process_leaf` inside `_flatten_event`, so small per-field savings
-compound over millions of fields. A few caches keep that path lean while leaving
-the flattened output (and therefore detections) unchanged:
-
-- **`_special_fields`** — built once in `_load_config` from the configured
-  alias, split, and (when enabled) transform field names. Most leaves appear in
-  none of these, so a single set membership check lets them take an *ultra-fast
-  path* (assign the value, record the column type once) instead of the
-  alias/split/transform lookups. Only "special" leaves enter the fuller logic.
-- **`_seen_leaf_keys`** — once a leaf key has had its column recorded, later
-  events with the same key skip the `str.lower()` and `discovered_fields`
-  bookkeeping. Large-integer normalization (values outside signed 64-bit are
-  stored as text) still runs for *every* value, because the same field can carry
-  an over-range value in a later event.
-- **Event-filter path hints** — `_extract_field_value_hinted` remembers which
-  configured path produced the `Channel`/`EventID` on the previous event and
-  tries it first. A file's schema is stable, so this usually hits; on a miss it
-  falls back to the full ordered scan, keeping results identical.
-- **Batch insert** — `_insert_batch` uses a single `operator.itemgetter` for
-  homogeneous batches (every event shares the first event's columns) and keeps
-  the per-column `dict.get` path for heterogeneous batches so missing columns
-  still map to `NULL`.
-
-The `tools/flatten-benchmark.py` harness reports steady-state flattening
-throughput (events/second) on a fixed corpus for measuring changes to this path.
-
 ### Processing Modes
 
 ```mermaid

--- a/docs/Internals.md
+++ b/docs/Internals.md
@@ -79,6 +79,35 @@ flowchart TB
 | **5. Splits** | Parse key=value strings | `"a=1 b=2"` → `{a:1, b:2}` |
 | **6. Transforms** | Custom Python code (sandboxed) | Extract filename from path |
 
+### Flattening Hot Path
+
+Flattening is the dominant cost of ingestion: every leaf of every event passes
+through `process_leaf` inside `_flatten_event`, so small per-field savings
+compound over millions of fields. A few caches keep that path lean while leaving
+the flattened output (and therefore detections) unchanged:
+
+- **`_special_fields`** — built once in `_load_config` from the configured
+  alias, split, and (when enabled) transform field names. Most leaves appear in
+  none of these, so a single set membership check lets them take an *ultra-fast
+  path* (assign the value, record the column type once) instead of the
+  alias/split/transform lookups. Only "special" leaves enter the fuller logic.
+- **`_seen_leaf_keys`** — once a leaf key has had its column recorded, later
+  events with the same key skip the `str.lower()` and `discovered_fields`
+  bookkeeping. Large-integer normalization (values outside signed 64-bit are
+  stored as text) still runs for *every* value, because the same field can carry
+  an over-range value in a later event.
+- **Event-filter path hints** — `_extract_field_value_hinted` remembers which
+  configured path produced the `Channel`/`EventID` on the previous event and
+  tries it first. A file's schema is stable, so this usually hits; on a miss it
+  falls back to the full ordered scan, keeping results identical.
+- **Batch insert** — `_insert_batch` uses a single `operator.itemgetter` for
+  homogeneous batches (every event shares the first event's columns) and keeps
+  the per-column `dict.get` path for heterogeneous batches so missing columns
+  still map to `NULL`.
+
+The `tools/flatten-benchmark.py` harness reports steady-state flattening
+throughput (events/second) on a fixed corpus for measuring changes to this path.
+
 ### Processing Modes
 
 ```mermaid

--- a/tests/test_streaming_processor.py
+++ b/tests/test_streaming_processor.py
@@ -218,6 +218,171 @@ class TestStreamingEventProcessorFlattening:
         assert result is None
 
 
+class TestFlattenHotPathOptimizations:
+    """Tests for the flattening fast path (special fields, seen-key caching)."""
+
+    def test_special_fields_only_split_when_no_alias_or_transform(
+        self, field_mappings_file, test_logger, default_args_config
+    ):
+        """Minimal config has one split field and no aliases/transforms."""
+        processor = StreamingEventProcessor(
+            config_file=field_mappings_file,
+            args_config=default_args_config,
+            logger=test_logger,
+        )
+        assert processor._special_fields == {"Hashes"}
+
+    def test_special_fields_include_alias_and_transform_targets(
+        self, field_mappings_file_with_transforms, test_logger, default_args_config
+    ):
+        """Alias and (enabled) transform field names are flagged as special."""
+        processor = StreamingEventProcessor(
+            config_file=field_mappings_file_with_transforms,
+            args_config=default_args_config,
+            logger=test_logger,
+        )
+        assert processor._special_fields == {"CommandLine", "proctitle"}
+
+    def test_fast_path_assigns_value_and_discovers_field(
+        self, field_mappings_file, test_logger, default_args_config
+    ):
+        """A non-special leaf is assigned and its column type recorded once."""
+        processor = StreamingEventProcessor(
+            config_file=field_mappings_file,
+            args_config=default_args_config,
+            logger=test_logger,
+        )
+        event = {"Event": {"System": {"EventID": 4688, "Channel": "Security"}}}
+        flat = processor._flatten_event(event, "t.evtx")
+        assert flat["EventID"] == 4688
+        assert flat["Channel"] == "Security"
+        assert processor.field_types["EventID"] == "INTEGER"
+        assert processor.field_types["Channel"] == "TEXT COLLATE NOCASE"
+        # The key is now remembered so repeat work is skipped.
+        assert "EventID" in processor._seen_leaf_keys
+
+    def test_seen_key_repeat_large_int_still_stringified(
+        self, field_mappings_file, test_logger, default_args_config
+    ):
+        """A >int64 value on an already-seen key must still be stringified."""
+        processor = StreamingEventProcessor(
+            config_file=field_mappings_file,
+            args_config=default_args_config,
+            logger=test_logger,
+        )
+        huge = 9223372036854775807 + 10  # exceeds signed 64-bit range
+        first = processor._flatten_event(
+            {"Event": {"System": {"EventID": 1}}}, "t.evtx"
+        )
+        second = processor._flatten_event(
+            {"Event": {"System": {"EventID": huge}}}, "t.evtx"
+        )
+        assert first["EventID"] == 1
+        assert second["EventID"] == str(huge)
+        assert isinstance(second["EventID"], str)
+
+    def test_int64_min_is_stringified_like_baseline(
+        self, field_mappings_file, test_logger, default_args_config
+    ):
+        """INT64_MIN trips the abs()-based overflow guard (historical behaviour)."""
+        processor = StreamingEventProcessor(
+            config_file=field_mappings_file,
+            args_config=default_args_config,
+            logger=test_logger,
+        )
+        int64_min = -9223372036854775808
+        flat = processor._flatten_event(
+            {"Event": {"System": {"EventID": int64_min}}}, "t.evtx"
+        )
+        assert flat["EventID"] == str(int64_min)
+
+    def test_split_only_field_drops_original_and_repeats(
+        self, field_mappings_file, test_logger, default_args_config
+    ):
+        """Split-only fields emit sub-fields (dropping the original) every event."""
+        processor = StreamingEventProcessor(
+            config_file=field_mappings_file,
+            args_config=default_args_config,
+            logger=test_logger,
+        )
+        first = processor._flatten_event(
+            {"Event": {"EventData": {"Hashes": "MD5=aaa,SHA256=bbb"}}}, "t.evtx"
+        )
+        assert first["MD5"] == "aaa"
+        assert first["SHA256"] == "bbb"
+        assert "Hashes" not in first
+        # Second event with the same (now seen) sub-keys still splits correctly.
+        second = processor._flatten_event(
+            {"Event": {"EventData": {"Hashes": "MD5=ccc,SHA256=ddd"}}}, "t.evtx"
+        )
+        assert second["MD5"] == "ccc"
+        assert second["SHA256"] == "ddd"
+        assert "Hashes" not in second
+
+    def test_event_filter_path_hint_reused_and_falls_back(
+        self, field_mappings_file, test_logger, default_args_config
+    ):
+        """The winning channel/eventid path is cached and reused, with fallback."""
+        processor = StreamingEventProcessor(
+            config_file=field_mappings_file,
+            args_config=default_args_config,
+            logger=test_logger,
+        )
+        e1 = {"Event": {"System": {"Channel": "Sysmon", "EventID": 1}}}
+        channel, eventid = processor._extract_event_filter_fields(e1)
+        assert channel == "Sysmon"
+        assert eventid == 1
+        assert processor._channel_path_hint == ("Event", "System", "Channel")
+        assert processor._eventid_path_hint == ("Event", "System", "EventID")
+
+        # Same schema: hint hit yields identical results.
+        assert processor._extract_event_filter_fields(e1) == ("Sysmon", 1)
+
+        # Different schema: hint misses, full scan finds the direct fields and
+        # updates the hint.
+        e2 = {"Channel": "Security", "EventID": 4624}
+        channel2, eventid2 = processor._extract_event_filter_fields(e2)
+        assert channel2 == "Security"
+        assert eventid2 == 4624
+        assert processor._channel_path_hint == ("Channel",)
+        assert processor._eventid_path_hint == ("EventID",)
+
+    def test_insert_batch_homogeneous_and_heterogeneous(
+        self, field_mappings_file, test_logger, default_args_config
+    ):
+        """itemgetter path (homogeneous) and .get path (heterogeneous) agree."""
+        processor = StreamingEventProcessor(
+            config_file=field_mappings_file,
+            args_config=default_args_config,
+            logger=test_logger,
+        )
+        conn = sqlite3.connect(":memory:")
+        cur = conn.cursor()
+        cur.execute('CREATE TABLE logs ("Alpha" TEXT, "Beta" TEXT, "Solo" TEXT)')
+        conn.commit()
+
+        # Homogeneous, multi-column -> itemgetter fast path.
+        processor._insert_batch(
+            conn, cur, [{"Alpha": "a1", "Beta": "b1"}, {"Alpha": "a2", "Beta": "b2"}]
+        )
+        assert cur.execute(
+            'SELECT "Alpha", "Beta" FROM logs ORDER BY "Alpha"'
+        ).fetchall() == [("a1", "b1"), ("a2", "b2")]
+
+        # Single-column -> guarded .get path (itemgetter would return a scalar).
+        processor._insert_batch(conn, cur, [{"Solo": "s1"}])
+        assert cur.execute(
+            'SELECT "Solo" FROM logs WHERE "Solo" IS NOT NULL'
+        ).fetchall() == [("s1",)]
+
+        # Heterogeneous -> .get path, missing columns become NULL.
+        processor._insert_batch(conn, cur, [{"Alpha": "x"}, {"Beta": "y"}])
+        rows = set(cur.execute('SELECT "Alpha", "Beta" FROM logs').fetchall())
+        assert ("x", None) in rows
+        assert (None, "y") in rows
+        conn.close()
+
+
 class TestStreamingEventProcessorSchemaGeneration:
     """Tests for SQL schema generation."""
     

--- a/tools/README.md
+++ b/tools/README.md
@@ -77,3 +77,39 @@ pdm run python tools/sigma-regression.py \
 - `1` if any test failed or the script could not load the ruleset / find regression data.
 
 Skipped tests (missing data file or no matching rule in the ruleset) are reported in the summary but do not change the exit code unless you treat "skipped" as failure in your workflow.
+
+## flatten-benchmark.py
+
+Measures Zircolite's event-**flattening** throughput, isolated from EVTX parsing, SQLite insertion, and rule execution. Flattening is the dominant cost of log ingestion, so this harness is useful when changing the `_flatten_event` / `process_leaf` hot path.
+
+The script reads raw events once, then repeatedly calls `StreamingEventProcessor._flatten_event` over them. The first pass warms schema discovery and the seen-key cache, so the reported numbers reflect steady-state flattening.
+
+### Arguments
+
+- **`--evtx`** (required): Path to an EVTX file or a directory of EVTX files (searched recursively).
+- **`--config`**: Field mappings config file (default: `config/config.yaml`).
+- **`--max-events`**: Maximum number of events to load and flatten (default: `20000`).
+- **`--passes`**: Number of timed passes over the loaded events (default: `11`); the median and best are reported.
+
+### Usage
+
+From the Zircolite project root:
+
+```bash
+# Single file
+pdm run python tools/flatten-benchmark.py --evtx sample.evtx
+
+# Directory of EVTX files, custom event count and pass count
+pdm run python tools/flatten-benchmark.py \
+  --evtx /path/to/EVTX-ATTACK-SAMPLES \
+  --max-events 20000 --passes 11
+```
+
+### Output
+
+Prints the event count and, for the timed passes, the median and best wall time plus the corresponding events/second.
+
+### Exit code
+
+- `0` on success.
+- `1` if no events could be collected (for example, a bad `--evtx` path or a capture with no standard records).

--- a/tools/flatten-benchmark.py
+++ b/tools/flatten-benchmark.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""
+Measure Zircolite's event-flattening throughput on a fixed corpus.
+
+Flattening (turning nested EVTX/JSON events into flat rows) is the dominant
+cost when ingesting logs, so this harness isolates it from EVTX parsing, the
+SQLite insert, and rule execution. It reads raw events once, then repeatedly
+calls ``StreamingEventProcessor._flatten_event`` and reports events/second.
+
+The first pass warms schema discovery and the seen-key cache, so the reported
+numbers reflect steady-state flattening (the common case for a large file).
+
+Example:
+  pdm run python tools/flatten-benchmark.py --evtx sample.evtx
+  pdm run python tools/flatten-benchmark.py --evtx /path/to/EVTX-ATTACK-SAMPLES \
+      --max-events 20000 --passes 11 --config config/config.yaml
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import statistics
+import sys
+import time
+from argparse import Namespace
+from pathlib import Path
+
+import orjson
+from evtx import PyEvtxParser
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from zircolite import ProcessingConfig, StreamingEventProcessor  # noqa: E402
+
+
+def collect_raw_events(path: Path, limit: int) -> list:
+    """Parse up to *limit* raw (pre-flatten) event dicts from EVTX file(s)."""
+    if path.is_dir():
+        files = sorted(path.rglob("*.evtx"))
+    else:
+        files = [path]
+
+    raws: list = []
+    for evtx_file in files:
+        try:
+            parser = PyEvtxParser(str(evtx_file))
+            for record in parser.records_json():
+                raws.append(orjson.loads(record["data"]))
+                if len(raws) >= limit:
+                    return raws
+        except Exception:
+            # Skip unreadable/non-record captures and keep collecting.
+            continue
+    return raws
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--evtx", required=True, help="Path to an EVTX file or a directory of them"
+    )
+    ap.add_argument(
+        "--config", default="config/config.yaml", help="Field mappings config file"
+    )
+    ap.add_argument(
+        "--max-events", type=int, default=20000, help="Max events to load and flatten"
+    )
+    ap.add_argument(
+        "--passes", type=int, default=11, help="Timed passes over the loaded events"
+    )
+    args = ap.parse_args()
+
+    logging.disable(logging.CRITICAL)
+
+    raws = collect_raw_events(Path(args.evtx).expanduser(), args.max_events)
+    if not raws:
+        print("No events collected; check the --evtx path.", file=sys.stderr)
+        return 1
+
+    processor = StreamingEventProcessor(
+        config_file=args.config,
+        args_config=Namespace(
+            evtx_input=True, all_transforms=False, transform_categories=None
+        ),
+        processing_config=ProcessingConfig(),
+    )
+    flatten = processor._flatten_event
+
+    # Warm up so we measure steady-state flattening, not first-sighting work.
+    for event in raws:
+        flatten(event, "benchmark.evtx")
+
+    durations = []
+    for _ in range(args.passes):
+        start = time.perf_counter()
+        for event in raws:
+            flatten(event, "benchmark.evtx")
+        durations.append(time.perf_counter() - start)
+
+    count = len(raws)
+    median = statistics.median(durations)
+    best = min(durations)
+    print(f"events:        {count:,}")
+    print(f"passes:        {args.passes}")
+    print(f"median:        {median * 1000:.2f} ms  ({count / median:,.0f} events/s)")
+    print(f"best:          {best * 1000:.2f} ms  ({count / best:,.0f} events/s)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/zircolite/streaming.py
+++ b/zircolite/streaming.py
@@ -13,12 +13,13 @@ import base64
 import csv as csv_module
 import logging
 import math
+import operator
 import os
 import re
 import tempfile
 import time
 from pathlib import Path
-from typing import Any, Dict, FrozenSet, Generator, List, NamedTuple, Optional, Set, Tuple, TYPE_CHECKING, cast
+from typing import Any, Dict, FrozenSet, Generator, List, NamedTuple, Optional, Set, Tuple, TYPE_CHECKING
 
 import chardet
 import orjson as json
@@ -164,9 +165,16 @@ class StreamingEventProcessor:
         "transform_categories",
         "transforms_dir",
         "chosen_input",
+        # Field names that need alias/split/transform handling. Leaves whose
+        # mapped or raw name is absent here take the ultra-fast leaf path.
+        "_special_fields",
         # Event filter config (from fieldMappings config)
         "_channel_field_paths",
         "_eventid_field_paths",
+        # Last field path that yielded a Channel/EventID value; tried first on
+        # the next event since a file's schema is stable
+        "_channel_path_hint",
+        "_eventid_path_hint",
         # Timestamp config (from fieldMappings config)
         "_timestamp_detection_fields",
         "_timestamp_auto_detect",
@@ -175,6 +183,8 @@ class StreamingEventProcessor:
         "discovered_fields",
         "field_types",
         "field_stmt_cache",
+        # Leaf keys whose schema bookkeeping is already done (skip repeat work)
+        "_seen_leaf_keys",
         # Caches
         "compiled_code_cache",
         "_transform_func_cache",
@@ -257,6 +267,13 @@ class StreamingEventProcessor:
         self.discovered_fields: dict = {}  # field_name_lower -> original_field_name
         self.field_types: dict = {}  # field_name -> 'INTEGER' or 'TEXT'
         self.field_stmt_cache: dict = {}
+        # Leaf keys already passed through schema bookkeeping. Shares the
+        # lifetime of discovered_fields (never cleared mid-instance).
+        self._seen_leaf_keys: set = set()
+
+        # Event-filter path hints (populated lazily during streaming)
+        self._channel_path_hint: Optional[tuple] = None
+        self._eventid_path_hint: Optional[tuple] = None
 
         # Caches for transforms
         self.compiled_code_cache: dict = {}
@@ -455,6 +472,16 @@ class StreamingEventProcessor:
                         seen_codes.add(spec.code)
                         self._get_transform_func(spec.code)
 
+        # Fields that require alias, split, or transform handling. A leaf whose
+        # mapped key and raw name are both absent here cannot produce extra
+        # columns, so it skips the alias/split/transform lookups entirely.
+        # Transform fields only count when the engine is enabled, mirroring the
+        # ``not transforms_enabled`` short-circuit in the per-leaf fast path.
+        special_fields = set(self.aliases) | set(self.field_split_list)
+        if self.transforms_enabled:
+            special_fields |= set(self._transforms_baked)
+        self._special_fields = special_fields
+
     def _resolve_file_transforms(self):
         """Resolve python_file transforms by loading code from external files.
 
@@ -512,8 +539,12 @@ class StreamingEventProcessor:
         Returns:
             Tuple of (channel, eventid) where eventid is int or None
         """
-        channel = self._extract_field_value(event_dict, self._channel_field_paths)
-        eventid = self._extract_field_value(event_dict, self._eventid_field_paths)
+        channel, self._channel_path_hint = self._extract_field_value_hinted(
+            event_dict, self._channel_field_paths, self._channel_path_hint
+        )
+        eventid, self._eventid_path_hint = self._extract_field_value_hinted(
+            event_dict, self._eventid_field_paths, self._eventid_path_hint
+        )
 
         # Convert eventid to int if possible (guarantees int or None for caller)
         if eventid is not None:
@@ -546,6 +577,33 @@ class StreamingEventProcessor:
             if value is not None:
                 return value
         return None
+
+    def _extract_field_value_hinted(
+        self, event_dict: dict, field_paths: tuple, hint: Optional[tuple]
+    ) -> tuple:
+        """
+        Like :meth:`_extract_field_value`, but try the last winning path first.
+
+        A log file's schema is stable, so the path that produced a value on the
+        previous event almost always produces it again. Probing that path first
+        avoids re-walking earlier candidate paths that are absent from the
+        event. On a miss the full ordered scan runs as before, keeping results
+        identical to a plain first-match scan.
+
+        Returns:
+            Tuple of (value, winning_path). ``winning_path`` is the path that
+            produced the value (the new hint), or the unchanged hint when no
+            path matched.
+        """
+        if hint is not None:
+            value = self._get_nested_value(event_dict, hint)
+            if value is not None:
+                return value, hint
+        for path in field_paths:
+            value = self._get_nested_value(event_dict, path)
+            if value is not None:
+                return value, path
+        return None, hint
 
     def _get_nested_value(self, obj: dict, parts: tuple) -> Any:
         """
@@ -688,6 +746,8 @@ class StreamingEventProcessor:
         field_types = self.field_types
         transform_value = self._transform_value
         resolve_path = self._resolve_path
+        special_fields = self._special_fields
+        seen_leaf_keys = self._seen_leaf_keys
         _sentinel = _EXCLUDED_SENTINEL
 
         # Result dict
@@ -705,6 +765,26 @@ class StreamingEventProcessor:
             if value in useless_values:
                 return
             key = mapped_key
+
+            # Ultra-fast path: the vast majority of leaves have no alias, split
+            # rule, or active transform. They only need a value assignment plus a
+            # one-time column-type record, so they skip the lookups below.
+            if key not in special_fields and raw_field_name not in special_fields:
+                is_int = isinstance(value, int)
+                if is_int and abs(value) > 9223372036854775807:
+                    value = str(value)
+                    is_int = False
+                json_line[key] = value
+                if key not in seen_leaf_keys:
+                    key_lower = key.lower()
+                    if key_lower not in discovered_fields:
+                        discovered_fields[key_lower] = key
+                        field_types[key] = (
+                            "INTEGER" if is_int else "TEXT COLLATE NOCASE"
+                        )
+                    seen_leaf_keys.add(key)
+                return
+
             alias_key = aliases_get(key)
             alias_raw = aliases_get(raw_field_name)
             split_config = field_split_list_get(
@@ -714,32 +794,23 @@ class StreamingEventProcessor:
                 no_transforms = not transforms_enabled or (
                     not transforms_get(key) and not transforms_get(raw_field_name)
                 )
-                if no_transforms:
-                    if split_config:
-                        try:
-                            separator = split_config["separator"]
-                            equal_sign = split_config["equal"]
-                            for split_field in value.split(separator):
-                                k, v = split_field.split(equal_sign)
-                                json_line[k] = v
+                if no_transforms and split_config:
+                    # Split-only field: emit the parsed sub-fields and drop the
+                    # original key (preserves the historical fast-path behaviour).
+                    try:
+                        separator = split_config["separator"]
+                        equal_sign = split_config["equal"]
+                        for split_field in value.split(separator):
+                            k, v = split_field.split(equal_sign)
+                            json_line[k] = v
+                            if k not in seen_leaf_keys:
                                 key_lower = k.lower()
                                 if key_lower not in discovered_fields:
                                     discovered_fields[key_lower] = k
                                     field_types[k] = "TEXT COLLATE NOCASE"
-                        except (ValueError, KeyError, AttributeError):
-                            pass
-                        return
-                    is_int = isinstance(value, int)
-                    if is_int:
-                        v_int = cast(int, value)
-                        if abs(v_int) > 9223372036854775807:
-                            value = str(value)
-                            is_int = False
-                    json_line[key] = value
-                    key_lower = key.lower()
-                    if key_lower not in discovered_fields:
-                        discovered_fields[key_lower] = key
-                        field_types[key] = "INTEGER" if is_int else "TEXT COLLATE NOCASE"
+                                seen_leaf_keys.add(k)
+                    except (ValueError, KeyError, AttributeError):
+                        pass
                     return
             keys = [key]
             if alias_key is not None:
@@ -780,28 +851,30 @@ class StreamingEventProcessor:
                     for split_field in value.split(separator):
                         k, v = split_field.split(equal_sign)
                         json_line[k] = v
-                        key_lower = k.lower()
-                        if key_lower not in discovered_fields:
-                            discovered_fields[key_lower] = k
-                            field_types[k] = "TEXT COLLATE NOCASE"
+                        if k not in seen_leaf_keys:
+                            key_lower = k.lower()
+                            if key_lower not in discovered_fields:
+                                discovered_fields[key_lower] = k
+                                field_types[k] = "TEXT COLLATE NOCASE"
+                            seen_leaf_keys.add(k)
                 except (ValueError, KeyError, AttributeError):
                     pass
             is_int = isinstance(value, int)
-            if is_int:
-                v_int = cast(int, value)
-                if abs(v_int) > 9223372036854775807:
-                    value = str(value)
-                    is_int = False
+            if is_int and abs(value) > 9223372036854775807:
+                value = str(value)
+                is_int = False
             has_transforms = transformed_keys is not None
             for k in keys:
                 if has_transforms and k in transformed_keys:
                     json_line[k] = transformed_values[k]
                 else:
                     json_line[k] = value
-                key_lower = k.lower()
-                if key_lower not in discovered_fields:
-                    discovered_fields[key_lower] = k
-                    field_types[k] = "INTEGER" if is_int else "TEXT COLLATE NOCASE"
+                if k not in seen_leaf_keys:
+                    key_lower = k.lower()
+                    if key_lower not in discovered_fields:
+                        discovered_fields[key_lower] = k
+                        field_types[k] = "INTEGER" if is_int else "TEXT COLLATE NOCASE"
+                    seen_leaf_keys.add(k)
 
         # Descend through the event tree, carrying the dotted path as a string
         # (cheaper than re-allocating a path tuple at every node). Leaves are
@@ -1490,8 +1563,15 @@ class StreamingEventProcessor:
             self._last_insert_stmt = insert_stmt
             self._last_insert_columns = all_columns
 
-        # Build rows – large-int normalisation already done in _flatten_event
-        rows = [tuple(event.get(col) for col in all_columns) for event in batch]
+        # Build rows – large-int normalisation already done in _flatten_event.
+        # When every event shares the first event's columns (the common case for
+        # a stable source), a single itemgetter beats a per-column .get genexpr.
+        # Heterogeneous batches keep .get so missing columns map to NULL.
+        if extra_columns is None and len(all_columns) > 1:
+            row_getter = operator.itemgetter(*all_columns)
+            rows = [row_getter(event) for event in batch]
+        else:
+            rows = [tuple(event.get(col) for col in all_columns) for event in batch]
 
         # Execute batch insert with transaction
         try:


### PR DESCRIPTION
## Summary

Event flattening is the dominant CPU cost of log ingestion: every leaf of every event passes through the per-field code in `_flatten_event`. This PR reduces the per-field work on that hot path while keeping flattened output (and therefore detections) byte-identical.

- Precompute a `_special_fields` set (alias / split / active-transform field names) in `_load_config`. Leaves whose mapped and raw names are both absent take an ultra-fast path (assign value + record column type once) instead of the alias/split/transform lookups; only "special" leaves enter the fuller logic.
- Add a `_seen_leaf_keys` cache so repeated leaf keys skip the `str.lower()` and schema bookkeeping. Large-integer normalization still runs on every value, so an over-range value on an already-seen key is still stored as text.
- Cache the winning Channel/EventID path in the event filter and try it first, falling back to the full ordered scan on a miss.
- Use `operator.itemgetter` for homogeneous insert batches (keeping the per-column `dict.get` path for heterogeneous batches) and drop redundant `typing.cast` calls.

Steady-state flattening throughput improves roughly 1.3-1.4x (~49k -> ~67k events/s) on a 20k-event benchmark. Adds `tools/flatten-benchmark.py` to measure flattening throughput on a fixed corpus.

## Related issue

N/A

## Checklist

- [x] Tests pass locally (`pdm run pytest`) - full suite passes (1139 tests).
- [x] Lint is clean (`pdm run ruff check zircolite/ zircolite.py`).
- [x] Documentation or help text updated if behavior or CLI changed.
- [x] No AI-attribution or optimization-tracking comments left in code.

Verified byte-identical output before/after over the EVTX-ATTACK-SAMPLES corpus (278 files): 332 detections and 34,990 flattened events match exactly after normalization. New unit tests cover special-field membership, repeat-key large-integer stringification, `INT64_MIN` handling, split fields on already-seen keys, event-filter path-hint reuse and fallback, and homogeneous vs. heterogeneous batch inserts.

Made with [Cursor](https://cursor.com)