### PR TITLE
Release v3.7.5

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Zircolite Documentation
 
-Documentation for **Zircolite 3.7.1**. Zircolite is a standalone SIGMA-based detection tool for EVTX, Auditd, Sysmon for Linux, XML, CSV, and JSONL/NDJSON logs. It uses SQLite as a backend for SIGMA rule execution.
+Documentation for **Zircolite 3.7.5**. Zircolite is a standalone SIGMA-based detection tool for EVTX, Auditd, Sysmon for Linux, XML, CSV, and JSONL/NDJSON logs. It uses SQLite as a backend for SIGMA rule execution.
 
 **Zircolite** supports the following log sources:
 

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -84,16 +84,16 @@ class TestBannerAndSection:
     def test_print_banner_visible_when_not_quiet(self):
         set_quiet_mode(False)
         with console.capture() as capture:
-            print_banner("3.7.1")
+            print_banner("3.7.5")
         out = capture.get()
         assert "Standalone Sigma" in out or "Sigma" in out
-        assert "3.7.1" in out
+        assert "3.7.5" in out
 
     def test_print_banner_suppressed_when_quiet(self):
         set_quiet_mode(True)
         try:
             with console.capture() as capture:
-                print_banner("3.7.1")
+                print_banner("3.7.5")
             assert capture.get() == ""
         finally:
             set_quiet_mode(False)

--- a/zircolite.py
+++ b/zircolite.py
@@ -1024,7 +1024,7 @@ def _run_processing(
 # MAIN
 ################################################################
 def main() -> None:
-    version = "3.7.1"
+    version = "3.7.5"
     args = parse_arguments()
 
     install_signal_handler()

--- a/zircolite/__init__.py
+++ b/zircolite/__init__.py
@@ -219,4 +219,4 @@ __all__ = [
     'print_detection',
 ]
 
-__version__ = "3.7.1"
+__version__ = "3.7.5"


### PR DESCRIPTION
## Summary

Version bump to **3.7.5** for release. The headline change for this release — faster event flattening (#135) — is already merged to `master`; this branch carries only the version bump so the release can be cut.

Bumped:
- `zircolite/__init__.py` — `__version__`
- `zircolite.py` — CLI banner version
- `docs/README.md` — documentation header
- `tests/test_console.py` — banner version assertions

(`pyproject.toml` is gitignored in this repo since v3.0.0 and is bumped locally only, per existing convention.)

## Release notes

### Performance
- **Faster event flattening** (#135) — reduced per-field work in the flattening hot path (`_flatten_event`), the dominant cost of log ingestion. Steady-state flattening throughput is roughly **1.3–1.4x higher**. Detection output and flattened rows are **byte-identical** to 3.7.1.
  - Precomputed "special fields" set so the common leaf skips the alias/split/transform lookups (ultra-fast path)
  - Per-processor seen-key cache skips repeated `str.lower()` and schema bookkeeping (large-integer normalization still runs on every value)
  - Event filter caches the winning `Channel`/`EventID` path and tries it first, falling back to a full scan on a miss
  - Homogeneous insert batches use a single `operator.itemgetter`

### Internal
- New `tools/flatten-benchmark.py` to measure steady-state flattening throughput on a fixed corpus
- Added regression tests for the flattening fast path (special-field membership, repeat-key large-integer handling, INT64_MIN, split-on-seen-key, event-filter path-hint reuse, batch inserts)
- Ignore local tool caches (pytest, ruff, mypy)

**Full Changelog**: https://github.com/wagga40/Zircolite/compare/v3.7.1...v3.7.5

## Related issue

N/A

## Checklist

- [x] Tests pass locally — `tests/test_console.py` (99 passed); package imports as `3.7.5`
- [x] Lint is clean (`pdm run ruff check zircolite/ zircolite.py`)
- [x] Documentation updated (`docs/README.md` version header)
- [x] No AI-attribution or optimization-tracking comments left in code

Made with [Cursor](https://cursor.com)