### PR TITLE
Release v3.7.6

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,51 @@
+# VCS
+.git
+.gitignore
+.github
+
+# Python environments & caches
+.venv
+venv
+__pycache__
+*.py[cod]
+.mypy_cache
+.pytest_cache
+.ruff_cache
+.coverage
+coverage
+htmlcov
+*.lcov
+
+# Build / packaging / dev-only sources
+build
+dist
+gui_dev
+helpers
+tools
+
+# Dev tooling, docs, project meta (not needed at runtime)
+docs
+pics
+tests
+*.md
+Taskfile*.yml
+pdm.lock
+pyproject.toml
+.cursor
+.cursorrules
+CLAUDE.md
+.claude
+.vscode
+.zed
+
+# OS junk & local outputs
+.DS_Store
+*.log
+detected_events.json
+detected_events.csv
+flattened_events_*.json
+fields.json
+tmp-*
+zircolite.tar
+zircogui-output-*
+*.evtx

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,39 +1,58 @@
 ARG PYTHON_VERSION="3.14-slim"
 
-FROM python:${PYTHON_VERSION}
+# ---- builder ----
+FROM python:${PYTHON_VERSION} AS builder
 
 ARG ZIRCOLITE_INSTALL_PREFIX="/opt"
 ARG ZIRCOLITE_REQUIREMENTS_FILE="requirements.txt"
+
+# Isolate dependencies in a venv so only resolved packages reach the runtime stage
+ENV VIRTUAL_ENV="/opt/venv" \
+    PATH="/opt/venv/bin:${PATH}"
+RUN python -m venv "${VIRTUAL_ENV}"
+
+WORKDIR ${ZIRCOLITE_INSTALL_PREFIX}/zircolite
+
+# Install dependencies first so this layer is cached across code changes
+COPY ${ZIRCOLITE_REQUIREMENTS_FILE} .
+RUN pip install --no-cache-dir -r ${ZIRCOLITE_REQUIREMENTS_FILE}
+
+# Static assets and application code
+COPY templates/ templates/
+COPY config/ config/
+COPY rules/ rules/
+COPY gui/ gui/
+COPY zircolite/ zircolite/
+COPY zircolite.py .
+
+# Refresh rulesets at build time (needs network); kept in the builder layer only
+RUN python3 zircolite.py -U
+
+# ---- runtime ----
+FROM python:${PYTHON_VERSION}
+
+ARG ZIRCOLITE_INSTALL_PREFIX="/opt"
 
 LABEL org.opencontainers.image.title="Zircolite" \
       org.opencontainers.image.description="A standalone SIGMA-based detection tool for EVTX, Auditd and Sysmon for Linux logs" \
       org.opencontainers.image.authors="wagga40" \
       org.opencontainers.image.source="https://github.com/wagga40/Zircolite"
 
+ENV VIRTUAL_ENV="/opt/venv" \
+    PATH="/opt/venv/bin:${PATH}" \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
 WORKDIR ${ZIRCOLITE_INSTALL_PREFIX}/zircolite
 
-# Copy and install Python dependencies
-COPY ${ZIRCOLITE_REQUIREMENTS_FILE} .
-RUN pip install --no-cache-dir -r ${ZIRCOLITE_REQUIREMENTS_FILE} && \
-    rm -rf ~/.cache/pip
+# The venv symlinks the base interpreter; safe because both stages share the same base image
+COPY --from=builder ${VIRTUAL_ENV} ${VIRTUAL_ENV}
+# Copy the app from the builder so the rulesets refreshed by -U are carried over
+COPY --from=builder ${ZIRCOLITE_INSTALL_PREFIX}/zircolite ${ZIRCOLITE_INSTALL_PREFIX}/zircolite
 
-# Copy static assets
-COPY templates/ templates/
-COPY config/ config/
-COPY rules/ rules/
-COPY gui/ gui/
-
-# Copy application code 
-COPY zircolite/ zircolite/
-COPY zircolite.py .
-
-# Set permissions and update rules in single layer
+# Run as a non-root user that owns every asset under the install prefix
 RUN chmod 0755 zircolite.py && \
-    python3 zircolite.py -U
-
-# Run as a non-root user. chown happens after -U so the unprivileged user
-# owns the refreshed rulesets and can read every asset under the install prefix.
-RUN groupadd --system zircolite && \
+    groupadd --system zircolite && \
     useradd --system --gid zircolite --home-dir ${ZIRCOLITE_INSTALL_PREFIX}/zircolite --shell /usr/sbin/nologin zircolite && \
     chown -R zircolite:zircolite ${ZIRCOLITE_INSTALL_PREFIX}/zircolite
 USER zircolite

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Zircolite Documentation
 
-Documentation for **Zircolite 3.7.5**. Zircolite is a standalone SIGMA-based detection tool for EVTX, Auditd, Sysmon for Linux, XML, CSV, and JSONL/NDJSON logs. It uses SQLite as a backend for SIGMA rule execution.
+Documentation for **Zircolite 3.7.6**. Zircolite is a standalone SIGMA-based detection tool for EVTX, Auditd, Sysmon for Linux, XML, CSV, and JSONL/NDJSON logs. It uses SQLite as a backend for SIGMA rule execution.
 
 **Zircolite** supports the following log sources:
 

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -84,16 +84,16 @@ class TestBannerAndSection:
     def test_print_banner_visible_when_not_quiet(self):
         set_quiet_mode(False)
         with console.capture() as capture:
-            print_banner("3.7.5")
+            print_banner("3.7.6")
         out = capture.get()
         assert "Standalone Sigma" in out or "Sigma" in out
-        assert "3.7.5" in out
+        assert "3.7.6" in out
 
     def test_print_banner_suppressed_when_quiet(self):
         set_quiet_mode(True)
         try:
             with console.capture() as capture:
-                print_banner("3.7.5")
+                print_banner("3.7.6")
             assert capture.get() == ""
         finally:
             set_quiet_mode(False)

--- a/zircolite.py
+++ b/zircolite.py
@@ -1024,7 +1024,7 @@ def _run_processing(
 # MAIN
 ################################################################
 def main() -> None:
-    version = "3.7.5"
+    version = "3.7.6"
     args = parse_arguments()
 
     install_signal_handler()

--- a/zircolite/__init__.py
+++ b/zircolite/__init__.py
@@ -219,4 +219,4 @@ __all__ = [
     'print_detection',
 ]
 
-__version__ = "3.7.5"
+__version__ = "3.7.6"


### PR DESCRIPTION
## Summary

- **Docker**: Split the image build into a builder and a runtime stage. Dependencies are installed into a virtualenv in the builder stage, and only the resolved packages plus the application (with rulesets refreshed via `-U`) are copied into a clean runtime image, keeping build tooling out of the final layer.
- **Build context**: Add `.dockerignore` so VCS metadata, dev tooling, docs, tests, and local outputs are excluded from the Docker build context.
- **Version**: Bump version to 3.7.6.

## Test plan

- [x] `pdm run pytest tests/test_console.py -k banner`
- [ ] Docker image builds successfully from the new multi-stage Dockerfile

Made with [Cursor](https://cursor.com)